### PR TITLE
Fix typo in test config doc

### DIFF
--- a/jekyll/_v3/test-configuration/what-are-requests-per-second-rps.md
+++ b/jekyll/_v3/test-configuration/what-are-requests-per-second-rps.md
@@ -13,7 +13,7 @@ Requests Per Second, RPS, or r/s is a scalability measure characterizing the thr
 
 Using RPS when defining sizing and scale of load testing is common when testing APIs, in the same way that the number of concurrent visitors or VUs is the most common concept and metric when talking about websites or apps.
 
-In the current version of Load Impact, sizing of load tests are defined by VUs. Converting the scale or size of a load test from VUs to RPS depends on a number of factors such as response times, script processing complexity and VU concurrency factors. When testing single API endpoints it's typically more logical to think in terms of request per second rather than concurrent users. For this reason, we have developed a sample script that can be used to maximize efficiency of the Virtual Users when testing an API endpoint. We take advantage of the ability of a Vitual User being able to open multiple connections in parallel.
+In the current version of Load Impact, sizing of load tests are defined by VUs. Converting the scale or size of a load test from VUs to RPS depends on a number of factors such as response times, script processing complexity and VU concurrency factors. When testing single API endpoints it's typically more logical to think in terms of request per second rather than concurrent users. For this reason, we have developed a sample script that can be used to maximize efficiency of the Virtual Users when testing an API endpoint. We take advantage of the ability of a Virtual User being able to open multiple connections in parallel.
 
 ***
 


### PR DESCRIPTION
Fix typo at the end of the test configuration:

_We take advantage of the ability of a Vi**r**tual User being able to open multiple connections in parallel._

URL: https://support.loadimpact.com/3.0/test-configuration/what-are-requests-per-second-rps/